### PR TITLE
Fix issue #4

### DIFF
--- a/bin/RefreshLiveCD
+++ b/bin/RefreshLiveCD
@@ -316,7 +316,7 @@ class Initramfs:
             "dracut",
             "--kver", kernel_version,
             "-m", "bash kernel-modules kernel-modules-extra udev-rules base fs-lib shutdown img-lib dmsquash-live",
-            "--filesystems", "squashfs iso9660",
+            "--filesystems", "squashfs iso9660 ext4",
             "--show-modules",
             "--force",
             "-L", "4"


### PR DESCRIPTION
This adds ext4 to the list of filesystems that can be mounted by dracut which solves [issue #4](https://github.com/gobolinux/LiveCD/issues/4), but only for the folks who use ext4. I'll assume this covers ~80% of the installations out there.